### PR TITLE
Update import of importlib

### DIFF
--- a/redis_cache/utils.py
+++ b/redis_cache/utils.py
@@ -1,12 +1,16 @@
 import warnings
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.importlib import import_module
 from redis.connection import SSLConnection
 
 from redis_cache.compat import (
     smart_text, python_2_unicode_compatible, parse_qs, urlparse
 )
+
+try:
+    import importlib
+except ImportError:
+    from django.utils import importlib
 
 try:
     basestring


### PR DESCRIPTION
Work around `RemovedInDjango19Warning`. Fixes #93
